### PR TITLE
Cachekoala fixes

### DIFF
--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -819,7 +819,7 @@ export function downloadForge(instanceName) {
     );
 
     const checkForgeSkip = await fse.pathExists(forgeJsonPath);
-    if (!checkForgeSkip && assetsCheckSkip) {
+    if (!(checkForgeSkip && assetsCheckSkip)) {
       const forgeJson = {};
 
       const sevenZipPath = await get7zPath();
@@ -1499,9 +1499,22 @@ export function downloadInstance(instanceName) {
         mcJson = (await axios.get(versionURL)).data;
         await fse.outputJson(mcJsonPath, mcJson);
       }
+      const libraries = librariesMapper(
+        mcJson.libraries,
+        _getLibrariesPath(state)
+      );
+
+      await extractNatives(
+        libraries,
+        // TODO: Central Natives Directory 1 of 2
+        // Switch to "path.join(_getNativeLibs(state), modloader[1])" to use a central copy of libs for X version.
+        path.join(_getInstancesPath(state), instanceName, "natives")
+        // pgetJVMArguments112ath.join(_getNativeLibs(state), modloader[1])
+      );
+
       if (modloader && modloader[0] === FABRIC) {
-        await dispatchEvent(downloadFabric(instanceName));
-      } else if (modloader && modloader[0] === FABRIC) {
+        await dispatch(downloadFabric(instanceName));
+      } else if (modloader && modloader[0] === FORGE) {
         await dispatch(downloadForge(instanceName));
       }
 
@@ -1510,8 +1523,17 @@ export function downloadInstance(instanceName) {
       }
       // Be aware that from this line the installer lock might be unlocked!
 
+
+
+
+      
       await dispatch(removeDownloadFromQueue(instanceName));
       dispatch(addNextInstanceToCurrentDownload());
+
+
+
+
+
     } else {
       // DOWNLOAD MINECRAFT JSON
       try {
@@ -1519,8 +1541,6 @@ export function downloadInstance(instanceName) {
       } catch (err) {
         const versionURL = mcVersions.find((v) => v.id === mcVersion).url;
         mcJson = (await axios.get(versionURL)).data;
-        // TODO: Move this lower in action to prevent false possitive downloads?
-        await fse.outputJson(mcJsonPath, mcJson);
       }
 
       // COMPUTING MC ASSETS
@@ -1605,6 +1625,9 @@ export function downloadInstance(instanceName) {
       if (mcJson.assets === "legacy") {
         await copyAssetsToLegacy(assets);
       }
+
+      // Fisnished downloading vanilla files. Can save json now to use as check.
+      await fse.outputJson(mcJsonPath, mcJson);
 
       if (modloader && modloader[0] === FABRIC) {
         await dispatch(downloadFabric(instanceName));
@@ -2630,10 +2653,10 @@ export function installMod(
     }
     await deps(mainModData.data);
 
-    async function deps(mainModData) {
+    async function deps(_mainModData) {
       if (installDeps) {
         await pMap(
-          mainModData.dependencies,
+          _mainModData.dependencies,
           async (dep) => {
             // type 1: embedded
             // type 2: optional

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -1522,18 +1522,8 @@ export function downloadInstance(instanceName) {
         await dispatch(processManifest(instanceName));
       }
       // Be aware that from this line the installer lock might be unlocked!
-
-
-
-
-      
       await dispatch(removeDownloadFromQueue(instanceName));
       dispatch(addNextInstanceToCurrentDownload());
-
-
-
-
-
     } else {
       // DOWNLOAD MINECRAFT JSON
       try {

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -2454,102 +2454,102 @@ export function installMod(
         );
         await deps(cachedManifest);
         // was not found in dedicated cache.
-      } else if (cacheModsInstances) {
-        // Check instances.
-        // Get existing instance with mods.
-        const instanceList = _getInstances(state);
-        const instancesWithMods = instanceList.filter((singleInstance) => {
-          if (!(singleInstance?.mods && singleInstance.mods.length !== 0))
-            return false;
-          return singleInstance.name !== instanceName;
-        });
+        return;
+      }
+    }
+    if (cacheModsInstances) {
+      // Check instances.
+      // Get existing instance with mods.
+      const instanceList = _getInstances(state);
+      const instancesWithMods = instanceList.filter((singleInstance) => {
+        if (!(singleInstance?.mods && singleInstance.mods.length !== 0))
+          return false;
+        return singleInstance.name !== instanceName;
+      });
 
-        // Copy from existing instance.
+      // Copy from existing instance.
 
-        // Copy from other instances if file exists.
-        const firstInstanceWithModMatch = instancesWithMods.find(
-          (singleInstance) =>
-            singleInstance.mods.some(
-              (mod) => mod.projectID === projectID && mod.fileID === fileID
-            )
+      // Copy from other instances if file exists.
+      const firstInstanceWithModMatch = instancesWithMods.find(
+        (singleInstance) =>
+          singleInstance.mods.some(
+            (mod) => mod.projectID === projectID && mod.fileID === fileID
+          )
+      );
+
+      if (firstInstanceWithModMatch) {
+        const modData = firstInstanceWithModMatch?.mods.find(
+          (mod) => mod.projectID === projectID
         );
 
-        if (firstInstanceWithModMatch) {
-          const modData = firstInstanceWithModMatch?.mods.find(
-            (mod) => mod.projectID === projectID
+        if (modData) {
+          const instanceDestFile = path.join(
+            _getInstancesPath(state),
+            instanceName,
+            modData?.categorySection?.path || "mods",
+            modData.fileName
           );
-
-          if (modData) {
-            const instanceDestFile = path.join(
+          const destFileExistsInstance = await fse.pathExists(instanceDestFile);
+          if (!destFileExistsInstance) {
+            const otherInstance = path.join(
               _getInstancesPath(state),
-              instanceName,
+              firstInstanceWithModMatch.name,
               modData?.categorySection?.path || "mods",
               modData.fileName
             );
-            const destFileExistsInstance = await fse.pathExists(
-              instanceDestFile
+
+            console.log(
+              `[Mod Cache] Retrieved from instance: ${modData.fileName}`
             );
-            if (!destFileExistsInstance) {
-              const otherInstance = path.join(
-                _getInstancesPath(state),
-                firstInstanceWithModMatch.name,
-                modData?.categorySection?.path || "mods",
-                modData.fileName
-              );
-
-              console.log(
-                `[Mod Cache] Retrieved from instance: ${modData.fileName}`
-              );
-              await fse.ensureDir(path.dirname(instanceDestFile));
-              try {
-                await fse.ensureLink(otherInstance, instanceDestFile);
-              } catch {
-                await fse.copyFile(otherInstance, instanceDestFile);
-              }
-
-              if (cacheMods) {
-                console.log(
-                  `[Mod Cache] Adding to cache from instance: ${modData.fileName}`
-                );
-                await fse.ensureDir(cachedModFolder);
-                try {
-                  await fse.ensureLink(
-                    otherInstance,
-                    path.join(cachedModFolder, modData.fileName)
-                  );
-                } catch {
-                  await fse.copyFile(
-                    otherInstance,
-                    path.join(cachedModFolder, modData.fileName)
-                  );
-                }
-                await fse.outputJson(
-                  path.join(cachedModFolder, manifestFile),
-                  modData
-                );
-              }
+            await fse.ensureDir(path.dirname(instanceDestFile));
+            try {
+              await fse.ensureLink(otherInstance, instanceDestFile);
+            } catch {
+              await fse.copyFile(otherInstance, instanceDestFile);
             }
 
-            await dispatch(
-              updateInstanceConfig(instanceName, (prev) => {
-                needToAddMod = !prev.mods.find(
-                  (v) => v.fileID === fileID && v.projectID === projectID
+            if (cacheMods) {
+              console.log(
+                `[Mod Cache] Adding to cache from instance: ${modData.fileName}`
+              );
+              await fse.ensureDir(cachedModFolder);
+              try {
+                await fse.ensureLink(
+                  otherInstance,
+                  path.join(cachedModFolder, modData.fileName)
                 );
-                return {
-                  ...prev,
-                  mods: [...prev.mods, ...(needToAddMod ? [modData] : [])],
-                };
-              })
-            );
-            await deps(modData);
+              } catch {
+                await fse.copyFile(
+                  otherInstance,
+                  path.join(cachedModFolder, modData.fileName)
+                );
+              }
+              await fse.outputJson(
+                path.join(cachedModFolder, manifestFile),
+                modData
+              );
+            }
           }
+
+          await dispatch(
+            updateInstanceConfig(instanceName, (prev) => {
+              needToAddMod = !prev.mods.find(
+                (v) => v.fileID === fileID && v.projectID === projectID
+              );
+              return {
+                ...prev,
+                mods: [...prev.mods, ...(needToAddMod ? [modData] : [])],
+              };
+            })
+          );
+          await deps(modData);
+          // eslint-disable-next-line no-useless-return
+          return;
         }
-        // Not found in instances.
-      } else {
-        // Download from Curseforge.
-        await downloadFromCurseforge();
       }
+      // Not found in instances.
     }
+    await downloadFromCurseforge();
 
     async function downloadFromCurseforge() {
       const mainModData = await getAddonFile(projectID, fileID);


### PR DESCRIPTION
## Purpose  
Fix for code I was sure I had changed previously...  
- Fixes quick asset skip logic for vanilla.  Was skipping natives extraction step.  
- Moves mc.json save to after downloading files. The mc.json file is what is used to quick skip.  
- Fix forge installer quick skip logic.  



Self rant:
I must have deleted a few commits some how switching branches, I had this all changed and working.
