### PR TITLE
Exporter

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -376,10 +376,10 @@ ipcMain.handle("open-devtools", () => {
   mainWindow.webContents.openDevTools({ mode: "undocked" });
 });
 
-ipcMain.handle("openFolderDialog", (e, defaultPath) => {
+ipcMain.handle("openFolderDialog", (e, _defaultPath) => {
   return dialog.showOpenDialog({
     properties: ["openDirectory"],
-    defaultPath: path.dirname(defaultPath),
+    defaultPath: _defaultPath,
   });
 });
 

--- a/src/common/modals/InstanceExport/CurseForge/FirstStep.js
+++ b/src/common/modals/InstanceExport/CurseForge/FirstStep.js
@@ -216,6 +216,7 @@ export default function FirstStep({
                         <Input
                           type="text"
                           name="inputPackVersion"
+                          value={packVersion}
                           defaultValue={packVersion}
                           maxLength={10}
                           allowClear="true"

--- a/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
+++ b/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
@@ -132,7 +132,15 @@ export default function ThirdStep({
             const match = selectedFiles.find(
               (file) => mod.fileName === path.basename(file)
             );
-            if (match && mod.projectID) return true;
+            if (
+              match &&
+              mod.projectID &&
+              mod?.fileName &&
+              fse.pathExists(
+                path.join(instancesPath, instanceName, mod.fileName)
+              )
+            )
+              return true;
             return false;
           })
         : selectedFiles;

--- a/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
+++ b/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
@@ -140,8 +140,9 @@ export default function ThirdStep({
               fse.pathExists(
                 path.join(instancesPath, instanceName, mod.fileName)
               )
-            )
+            ) {
               return true;
+            }
             return false;
           })
         : selectedFiles;

--- a/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
+++ b/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
@@ -10,6 +10,7 @@ import makeDir from "make-dir";
 import { Transition } from "react-transition-group";
 import styled from "styled-components";
 import pMap from "p-map";
+import { updateInstanceConfig } from "../../../reducers/actions";
 import { get7zPath } from "../../../../app/desktop/utils";
 import { FABRIC, VANILLA, FORGE } from "../../../utils/constants";
 
@@ -193,6 +194,13 @@ export default function ThirdStep({
 
       setIsCompleted(true);
     };
+
+    dispatch(
+      updateInstanceConfig(instanceName, (prev) => ({
+        ...prev,
+        exporter: { lastPath: filePath, version: packVersion },
+      }))
+    );
 
     workOnFiles();
   }, [page]);

--- a/src/common/modals/InstanceExport/CurseForge/index.js
+++ b/src/common/modals/InstanceExport/CurseForge/index.js
@@ -34,21 +34,24 @@ const InstanceExportCurseForge = ({ instanceName }) => {
   const instancePath = path.join(instancesPath, instanceName);
   const [exporterDirectory, setExporterDirectory] = useState("");
 
-  if (exporterDirectory === "") {
-    if (
-      instanceConfig?.exporter?.lastPath &&
-      fse.pathExists(instanceConfig?.exporter?.lastPath)
-    ) {
-      setExporterDirectory(instanceConfig.exporter.lastPath);
-      setFilePath(instanceConfig.exporter.lastPath);
-    } else {
-      setExporterDirectory(instancePath);
-    }
+  async function preLoadChecks() {
+    if (exporterDirectory === "") {
+      if (
+        instanceConfig?.exporter?.lastPath &&
+        (await fse.pathExists(instanceConfig.exporter.lastPath))
+      ) {
+        setExporterDirectory(instanceConfig.exporter.lastPath);
+        setFilePath(instanceConfig.exporter.lastPath);
+      } else {
+        setExporterDirectory(instancePath);
+      }
 
-    if (instanceConfig?.exporter?.version) {
-      setPackVersion(instanceConfig?.exporter?.version);
+      if (instanceConfig?.exporter?.version) {
+        setPackVersion(instanceConfig?.exporter?.version);
+      }
     }
   }
+  preLoadChecks();
 
   const openFolderDialog = async () => {
     const dialog = await ipcRenderer.invoke(

--- a/src/common/modals/InstanceExport/CurseForge/index.js
+++ b/src/common/modals/InstanceExport/CurseForge/index.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { useSelector } from "react-redux";
 import { ipcRenderer } from "electron";
 import path from "path";
+import fse from "fs-extra";
 import {
   _getInstance,
   _getCurrentAccount,
@@ -23,7 +24,7 @@ const InstanceExportCurseForge = ({ instanceName }) => {
   const currentAccount = useSelector(_getCurrentAccount);
   const username = currentAccount.selectedProfile.name;
   const [filePath, setFilePath] = useState(null);
-  const [packVersion, setPackVersion] = useState("1.0");
+  const [packVersion, setPackVersion] = useState("0.1.0");
   const [packAuthor, setPackAuthor] = useState(username);
   const [packZipName, setPackZipName] = useState(instanceName);
   const [selectedFiles, setSelectedFiles] = useState([]);
@@ -31,9 +32,29 @@ const InstanceExportCurseForge = ({ instanceName }) => {
   const tempPath = useSelector(_getTempPath);
   const [treeData, setTreeData] = useState([]);
   const instancePath = path.join(instancesPath, instanceName);
+  const [exporterDirectory, setExporterDirectory] = useState("");
+
+  if (exporterDirectory === "") {
+    if (
+      instanceConfig?.exporter?.lastPath &&
+      fse.pathExists(instanceConfig?.exporter?.lastPath)
+    ) {
+      setExporterDirectory(instanceConfig.exporter.lastPath);
+      setFilePath(instanceConfig.exporter.lastPath);
+    } else {
+      setExporterDirectory(instancePath);
+    }
+
+    if (instanceConfig?.exporter?.version) {
+      setPackVersion(instanceConfig?.exporter?.version);
+    }
+  }
 
   const openFolderDialog = async () => {
-    const dialog = await ipcRenderer.invoke("openFolderDialog", instancesPath);
+    const dialog = await ipcRenderer.invoke(
+      "openFolderDialog",
+      exporterDirectory
+    );
     if (dialog.canceled) return;
     setFilePath(dialog.filePaths[0]);
   };


### PR DESCRIPTION
## Purpose
To try and prevent duplicate projectid entries from invalid config.json data making curseforge reject submission.  

Make exporting updated versions of pack easier to do by:  
- Remembering last export location per pack.  
- Remembering last used semver number from last export per pack.  